### PR TITLE
Fix schema/resolver mismatches

### DIFF
--- a/server/resolvers/employee/index.js
+++ b/server/resolvers/employee/index.js
@@ -242,7 +242,7 @@ const employeeResolvers = {
       }
     },
 
-    recordAttendance: async (_, { input }, { user }) => {
+    createAttendanceRecord: async (_, { input }, { user }) => {
       if (!user) throw new AuthenticationError('인증이 필요합니다');
 
       try {

--- a/server/schema/employee/index.js
+++ b/server/schema/employee/index.js
@@ -6,6 +6,7 @@ const employeeSchema = gql`
     employeeNumber: String!
     name: String!
     email: String!
+    user: User
     department: String!
     position: String!
     hireDate: String!
@@ -16,7 +17,9 @@ const employeeSchema = gql`
     emergencyPhone: String
     salary: Float
     benefits: String
-    skills: [String]
+    skills: [Skill]
+    experiences: [Experience]
+    emergencyContacts: [EmergencyContact]
     avatar: String
     createdAt: String!
     updatedAt: String!

--- a/server/schema/sales/index.js
+++ b/server/schema/sales/index.js
@@ -44,6 +44,20 @@ const salesSchema = gql`
     CANCELLED
   }
 
+  type Payment {
+    id: ID!
+    salesItemId: ID!
+    salesItem: SalesItem
+    paymentDate: String!
+    amount: Float!
+    paymentMethod: PaymentMethod!
+    note: String
+    receiptImageUrl: String
+    isActive: Boolean!
+    createdAt: String!
+    updatedAt: String!
+  }
+
   input SalesItemInput {
     customerId: ID!
     productId: ID!
@@ -66,15 +80,91 @@ const salesSchema = gql`
     endDate: String
   }
 
+  input SalesItemBulkUpdate {
+    id: ID!
+    input: SalesItemInput!
+  }
+
+  input IncentivePayoutInput {
+    salesItemId: ID!
+    recipientId: ID!
+    paymentDate: String!
+    amount: Float!
+    type: String!
+    receiptImageUrl: String
+    note: String
+  }
+
+  type IncentivePayout {
+    id: ID!
+    salesItemId: ID!
+    salesItem: SalesItem
+    recipientId: ID!
+    recipient: User
+    paymentDate: String!
+    amount: Float!
+    type: String!
+    receiptImageUrl: String
+    note: String
+    isActive: Boolean!
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  type IncentivePayoutsResult {
+    success: Boolean!
+    incentivePayouts: [IncentivePayout!]!
+  }
+
+  type SalesItemHistory {
+    id: ID!
+    salesItemId: ID!
+    salesItem: SalesItem
+    userId: ID!
+    user: User
+    action: String!
+    field: String
+    oldValue: String
+    newValue: String
+    metadata: JSON
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  type SalesItemHistoriesResult {
+    success: Boolean!
+    histories: [SalesItemHistory!]!
+  }
+
+  type BulkUpdateSalesItemsResult {
+    success: Boolean!
+    message: String!
+    salesItems: [SalesItem!]!
+  }
+
+  type IncentivePayoutResponse {
+    success: Boolean!
+    incentivePayout: IncentivePayout
+    message: String!
+  }
+
   extend type Query {
     salesItems(filter: SalesFilterInput, limit: Int, offset: Int): [SalesItem!]!
     salesItem(id: ID!): SalesItem
+    salesReps(search: String, limit: Int): [User!]!
+    customersForSales(limit: Int, offset: Int): [Customer!]!
+    productsForSales(categoryId: ID, search: String, limit: Int): [Product!]!
+    productModelsForSales(productId: ID!, search: String, limit: Int): [ProductModel!]!
+    incentivePayouts(salesItemId: ID!, type: String): IncentivePayoutsResult!
+    salesItemHistories(salesItemId: ID!): SalesItemHistoriesResult!
   }
 
   extend type Mutation {
     createSalesItem(input: SalesItemInput!): SalesItem!
     updateSalesItem(id: ID!, input: SalesItemInput!): SalesItem!
     deleteSalesItem(id: ID!): DeleteResult!
+    bulkUpdateSalesItems(updates: [SalesItemBulkUpdate!]!): BulkUpdateSalesItemsResult!
+    createIncentivePayout(input: IncentivePayoutInput!): IncentivePayoutResponse!
   }
 `;
 


### PR DESCRIPTION
## Summary
- align `sales` schema with its resolvers
- expose `Employee` relations in schema
- sync attendance resolver name with schema

## Testing
- `node -e "const {makeExecutableSchema}=require('./server/node_modules/@graphql-tools/schema');const typeDefs=require('./server/schema');const resolvers=require('./server/resolvers');makeExecutableSchema({typeDefs,resolvers});console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_684e5b054844832bb4124ab1023574f8